### PR TITLE
Update chart-releaser arguments in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:
-          charts_dir: Helm
+          charts_dir: ${{ github.workspace }}/Helm
           pages_branch: main
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Update `charts_dir` parameter to try to allow `chart-releaser` to recognize the directory as a Helm chart