### PR TITLE
Update HELM to target Linux nodes only

### DIFF
--- a/Helm/virtualnode/Chart.yaml
+++ b/Helm/virtualnode/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Helm/virtualnode/templates/admissioncontroller.yaml
+++ b/Helm/virtualnode/templates/admissioncontroller.yaml
@@ -31,3 +31,15 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: {{ .Values.images.pullPolicy }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      

--- a/Helm/virtualnode/values.yaml
+++ b/Helm/virtualnode/values.yaml
@@ -28,8 +28,8 @@ securityContext:
       - NET_ADMIN
       - NET_RAW
 
-nodeSelector: {
-}
+nodeSelector: 
+  "kubernetes.io/os": linux
 
 # Lack of tolerations will ensure virtual node pods are not scheduled on a virtual node itself
 tolerations: []


### PR DESCRIPTION
- Updated to add node selector for linux only
- Updated AdmissionController to use same nodeSelector, affinity and tolerances as main StatefulSet
- Updated Chart version