### PR TITLE
Add documentation for chart repository

### DIFF
--- a/Docs/NodeCustomizations.md
+++ b/Docs/NodeCustomizations.md
@@ -1,6 +1,6 @@
 
 # Node Customizations
-The Helm chart in this repo is also published to the chart repository https://microsoft.github.io/virtualnodesOnAzureContainerInstances/.
+If you would like an alternate way to install virtual nodes on ACI, the Helm chart in this repo is also published to the chart repository https://microsoft.github.io/virtualnodesOnAzureContainerInstances/.
 
 Customizations to the virtual node Node configuration are generally done by modifying the values.yaml file for the HELM install and then running a `HELM upgrade` action. 
 

--- a/Docs/NodeCustomizations.md
+++ b/Docs/NodeCustomizations.md
@@ -1,5 +1,7 @@
 
 # Node Customizations
+The Helm chart in this repo is also published to the chart repository https://microsoft.github.io/virtualnodesOnAzureContainerInstances/.
+
 Customizations to the virtual node Node configuration are generally done by modifying the values.yaml file for the HELM install and then running a `HELM upgrade` action. 
 
 # Node Customization in HELM Values

--- a/Docs/NodeCustomizations.md
+++ b/Docs/NodeCustomizations.md
@@ -1,6 +1,6 @@
 
 # Node Customizations
-If you would like an alternate way to install virtual nodes on ACI, the Helm chart in this repo is also published to the chart repository https://microsoft.github.io/virtualnodesOnAzureContainerInstances/.
+If you would like an alternate way to install virtual nodes on ACI, the Helm chart in this repo is also published to the chart repository `https://microsoft.github.io/virtualnodesOnAzureContainerInstances/`.
 
 Customizations to the virtual node Node configuration are generally done by modifying the values.yaml file for the HELM install and then running a `HELM upgrade` action. 
 


### PR DESCRIPTION
Add documentation for the chart repository URL, for customers who would like an alternate way to install virtual nodes on ACI