### PR TITLE
Update FQDN rules with additional information

### DIFF
--- a/Docs/SecurityCustomizations.md
+++ b/Docs/SecurityCustomizations.md
@@ -122,6 +122,6 @@ You can reference the information below if you want to restrict outbound traffic
 
 The ACI cluster FQDN will always have the format `<clusterName>.<regionName>.atlas.cloudapp.azure.com`, where the value of `clusterName` is unique per cluster and the value of `regionName` corresponds to the region where the ACI cluster is deployed. For instance, a FQDN for an ACI cluster in Central India may look something like `sbzip4leutnry21.centralindia.atlas.cloudapp.azure.com`.
 
-The ACI cluster IP addresses will come out of the `AzureCloud` [service tag](https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview). You can get the IP address prefixes corresponding to this service tag [here](https://www.microsoft.com/en-us/download/details.aspx?id=56519).
+The ACI cluster IP addresses will be assigned from the `AzureCloud` [service tag](https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview). You can get the IP address prefixes corresponding to this service tag [here](https://www.microsoft.com/en-us/download/details.aspx?id=56519).
 
 Note that a single virtual node may be communicating with multiple ACI clusters - there is no guarantee of a 1:1 mapping from virtual node to ACI cluster.

--- a/Docs/SecurityCustomizations.md
+++ b/Docs/SecurityCustomizations.md
@@ -117,9 +117,11 @@ You can reference the information below if you want to restrict outbound traffic
 | Destination FQDN | Port | Use |
 | ------------- | --- | ------------- |
 | `management.azure.com`, or `Azure Resource Manager` service tag | HTTPS:443 | Required for the virtual node infrastructure to manage container groups that are deployed through the ACI ARM APIs for pods in the virtual node. |
-| `*.atlas.cloudapp.azure.com` | 19390 (TCP) | Required for the virtual node infrastructure to set up initial communication with the ACI clusters where container groups are deployed. It is also used to handle communication for CRI streaming APIs such as Exec and Attach. |
-| `*.atlas.cloudapp.azure.com` | 33391 (TCP) | Required for the virtual node infrastructure to communicate with the container runtime on the ACI clusters where container groups are deployed, for the purpose of performing lifecycle/management operations on containers. |
+| `*.atlas.cloudapp.azure.com` | 19390 (HTTP/TCP) | Required for the virtual node infrastructure to set up initial communication with the ACI clusters where container groups are deployed. It is also used to handle communication for CRI streaming APIs such as Exec and Attach. |
+| `*.atlas.cloudapp.azure.com` | 33391 (HTTP/TCP) | Required for the virtual node infrastructure to communicate with the container runtime on the ACI clusters where container groups are deployed, for the purpose of performing lifecycle/management operations on containers. |
 
 The ACI cluster FQDN will always have the format `<clusterName>.<regionName>.atlas.cloudapp.azure.com`, where the value of `clusterName` is unique per cluster and the value of `regionName` corresponds to the region where the ACI cluster is deployed. For instance, a FQDN for an ACI cluster in Central India may look something like `sbzip4leutnry21.centralindia.atlas.cloudapp.azure.com`.
+
+The ACI cluster IP addresses will come out of the `AzureCloud` [service tag](https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview). You can get the IP address prefixes corresponding to this service tag [here](https://www.microsoft.com/en-us/download/details.aspx?id=56519).
 
 Note that a single virtual node may be communicating with multiple ACI clusters - there is no guarantee of a 1:1 mapping from virtual node to ACI cluster.


### PR DESCRIPTION
Clarifies that virtual node infrastructure communication with ACI clusters may be performed over HTTP or TCP, and adds information about the IP addresses assigned to ACI clusters.