### PR TITLE
Adding branch protection policy

### DIFF
--- a/.github/policies/branch-protection.yml
+++ b/.github/policies/branch-protection.yml
@@ -1,0 +1,12 @@
+name: Default branch protection policy
+description: Requires one reviewer for merges into main branch
+resource: repository
+where: 
+configuration:
+  branchProtectionRules:
+    - branchNamePattern: main
+      requiredApprovingReviewsCount: 1
+      requireLastPushApproval: true
+      allowsForcePushes: false
+      dismissStaleReviews: true
+      isAdminEnforced: false


### PR DESCRIPTION
Adds new policies to satisfy SDL requirements:

Branch protection policy:

- Requires at least one reviewer other than author
- Requires review of latest push and resets previous votes
- Disables force pushes
- Enables admins to bypass
