### PR TITLE
Update index.yaml for chart version 1.3406.26050102

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,22 @@ apiVersion: v1
 entries:
   virtualnode:
   - apiVersion: v2
+    appVersion: 1.3406.26050102
+    created: "2026-05-04T18:50:53.561939813Z"
+    description: Helm chart to install virtual nodes on Azure Container Instances
+      to an existing Azure Kubernetes Service cluster.
+    digest: a390846ebad45299a510cd3b6aa2d0ef22f69e7951fab14a6de1196b7922686a
+    maintainers:
+    - name: Gabriel Fuhrman
+      url: https://github.com/Gfuhrm
+    - name: Justin Song
+      url: https://github.com/jussong-msft
+    name: virtualnode
+    type: application
+    urls:
+    - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-1.3406.26050102/virtualnode-1.3406.26050102.tgz
+    version: 1.3406.26050102
+  - apiVersion: v2
     appVersion: 1.3406.26042204
     created: "2026-04-28T20:58:52.597156793Z"
     description: Helm chart to install virtual nodes on Azure Container Instances
@@ -417,4 +433,4 @@ entries:
     urls:
     - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-0.0.1/virtualnode-0.0.1.tgz
     version: 0.0.1
-generated: "2026-04-28T20:58:52.597339557Z"
+generated: "2026-05-04T18:50:53.562197835Z"


### PR DESCRIPTION
Auto-generated Helm index update for chart version 1.3406.26050102 (main_20260501.2).

This updates the GitHub Pages Helm repo index to include the new chart release.