### PR TITLE
Update index.yaml for chart version 1.3408.26070201

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,22 @@ apiVersion: v1
 entries:
   virtualnode:
   - apiVersion: v2
+    appVersion: 1.3408.26070201
+    created: "2026-07-06T20:23:12.251958993Z"
+    description: Helm chart to install virtual nodes on Azure Container Instances
+      to an existing Azure Kubernetes Service cluster.
+    digest: 054f8df091168a43a8f02171271f44e215e7b56fcc68cfaece92d6209b215827
+    maintainers:
+    - name: Gabriel Fuhrman
+      url: https://github.com/Gfuhrm
+    - name: Justin Song
+      url: https://github.com/jussong-msft
+    name: virtualnode
+    type: application
+    urls:
+    - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-1.3408.26070201/virtualnode-1.3408.26070201.tgz
+    version: 1.3408.26070201
+  - apiVersion: v2
     appVersion: 1.3406.26062601
     created: "2026-06-26T17:53:31.381061185Z"
     description: Helm chart to install virtual nodes on Azure Container Instances
@@ -529,4 +545,4 @@ entries:
     urls:
     - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-0.0.1/virtualnode-0.0.1.tgz
     version: 0.0.1
-generated: "2026-06-26T17:53:31.381341658Z"
+generated: "2026-07-06T20:23:12.252469309Z"


### PR DESCRIPTION
Auto-generated Helm index update for chart version 1.3408.26070201 (main_20260702.1).

This updates the GitHub Pages Helm repo index to include the new chart release.