### PR TITLE
Update index.yaml for chart version 1.3409.26073001

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,22 @@ apiVersion: v1
 entries:
   virtualnode:
   - apiVersion: v2
+    appVersion: 1.3409.26073001
+    created: "2026-07-31T02:30:28.943902228Z"
+    description: Helm chart to install virtual nodes on Azure Container Instances
+      to an existing Azure Kubernetes Service cluster.
+    digest: 3fa277ca01e2321a3405dd0f9fa8097106086372187f2dc7e9975aaf617abac1
+    maintainers:
+    - name: Gabriel Fuhrman
+      url: https://github.com/Gfuhrm
+    - name: Justin Song
+      url: https://github.com/jussong-msft
+    name: virtualnode
+    type: application
+    urls:
+    - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-1.3409.26073001/virtualnode-1.3409.26073001.tgz
+    version: 1.3409.26073001
+  - apiVersion: v2
     appVersion: 1.3408.26072301
     created: "2026-07-24T18:53:21.87521377Z"
     description: Helm chart to install virtual nodes on Azure Container Instances
@@ -577,4 +593,4 @@ entries:
     urls:
     - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-0.0.1/virtualnode-0.0.1.tgz
     version: 0.0.1
-generated: "2026-07-24T18:53:21.875441945Z"
+generated: "2026-07-31T02:30:28.944221129Z"


### PR DESCRIPTION
Auto-generated index.yaml update from Chart Releaser Action for chart version `1.3409.26073001` (build `main_20260730.1`, k8s 1.34.9).