### PR TITLE
Update Helm index for chart version 1.3409.26080501 (main_20260805.1 image tags)

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,22 @@ apiVersion: v1
 entries:
   virtualnode:
   - apiVersion: v2
+    appVersion: 1.3409.26080501
+    created: "2026-08-06T00:00:42.585413906Z"
+    description: Helm chart to install virtual nodes on Azure Container Instances
+      to an existing Azure Kubernetes Service cluster.
+    digest: 97b43376a6cfc01b6ac329605adbc4851ad72dc1ee8ac850834f6095a47f8c03
+    maintainers:
+    - name: Gabriel Fuhrman
+      url: https://github.com/Gfuhrm
+    - name: Justin Song
+      url: https://github.com/jussong-msft
+    name: virtualnode
+    type: application
+    urls:
+    - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-1.3409.26080501/virtualnode-1.3409.26080501.tgz
+    version: 1.3409.26080501
+  - apiVersion: v2
     appVersion: 1.3409.26073001
     created: "2026-07-31T02:30:28.943902228Z"
     description: Helm chart to install virtual nodes on Azure Container Instances
@@ -593,4 +609,4 @@ entries:
     urls:
     - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-0.0.1/virtualnode-0.0.1.tgz
     version: 0.0.1
-generated: "2026-07-31T02:30:28.944221129Z"
+generated: "2026-08-06T00:00:42.585720344Z"


### PR DESCRIPTION
This PR updates the Helm chart index.yaml for chart version 1.3409.26080501, which includes updated image tags to main_20260805.1 (S360 Go module fixes).