### PR TITLE
Document AKS 1.35 compatibility and update README to AKS 1.34

### DIFF
--- a/Docs/VersionCompatibility.md
+++ b/Docs/VersionCompatibility.md
@@ -16,12 +16,13 @@ The ideal is for virtual nodes to be able to release versions which are fully fo
 
 Below are tested configurations which have been verified to be compatible
 
-| Virtual Node Version | AKS 1.29 | AKS 1.30 | AKS 1.31 | AKS 1.32 | AKS 1.33 | AKS 1.34 |
-|----------------------|----------|----------|----------|----------|----------|----------|
-| 1.29                 | ✅       | ❌      | ❌       | ❌      | ❌       | ❌      |
-| 1.30                 | ✅       | ✅      | ✅       | ✅      | ❓       | ❌      |
-| 1.32                 | ❌       | ❌      | ❌       | ✅      | ❓       | ❌      |
-| 1.33                 | ❌       | ❌      | ❌       | ✅      | ✅       | ✅*     |
-| 1.34                 | ❌       | ❌      | ❌       | ❓      | ✅       | ✅      |
+| Virtual Node Version | AKS 1.29 | AKS 1.30 | AKS 1.31 | AKS 1.32 | AKS 1.33 | AKS 1.34 | AKS 1.35 |
+|----------------------|----------|----------|----------|----------|----------|----------|----------|
+| 1.29                 | ✅       | ❌      | ❌       | ❌      | ❌       | ❌      | ❌      |
+| 1.30                 | ✅       | ✅      | ✅       | ✅      | ❓       | ❌      | ❌      |
+| 1.32                 | ❌       | ❌      | ❌       | ✅      | ❓       | ❌      | ❌      |
+| 1.33                 | ❌       | ❌      | ❌       | ✅      | ✅       | ✅*     | ❌      |
+| 1.34                 | ❌       | ❌      | ❌       | ❓      | ✅       | ✅      | ✅**    |
 
-\* VN2 1.3307.26033004 and higher compatible with AKS 1.34
+\* VN2 1.3307.26033004 and higher compatible with AKS 1.34  
+\*\* VN2 1.3410.26081102 and higher compatible with AKS 1.35. Note that virtual nodes continue to run 1.34 K8s binaries on an AKS 1.35 control plane, which is within the [supported version skew](https://kubernetes.io/releases/version-skew-policy/).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Suggested configuration of subnets:
 ||
 
 ### Step 3: Azure Kubernetes Service
-Create a new AKS cluster from Azure Portal, in the same RG from Step 1. Must be created using Subscription and Region from Prereqs. Must be configured to use network plugin “Azure CNI Node Subnet”, the VNET from Step 2, with the cluster to use the AKS subnet already created, and service CIDR / DNS need to be configured to be outside the existing VNET subnets. Use Kubernetes version 1.33.* and automatic upgrade to “enabled with patch”. Nodes selected for AKS must be at least 4 CPU and 16 GB RAM to accomodate virtual nodes being run on them, though they can be larger. 
+Create a new AKS cluster from Azure Portal, in the same RG from Step 1. Must be created using Subscription and Region from Prereqs. Must be configured to use network plugin “Azure CNI Node Subnet”, the VNET from Step 2, with the cluster to use the AKS subnet already created, and service CIDR / DNS need to be configured to be outside the existing VNET subnets. Use Kubernetes version 1.34.* and automatic upgrade to “enabled with patch”. Nodes selected for AKS must be at least 4 CPU and 16 GB RAM to accomodate virtual nodes being run on them, though they can be larger. 
 
 Arrows added to below pictures for the important fields
 
@@ -130,7 +130,7 @@ Arrows added to below pictures for the important fields
 ![AKS Basics](/Docs/Pictures/vn_aks_basics.png)
 
 ^ Must be created using Subscription from Prereqs and Region from Limitations.  
-^ Use Kubernetes version 1.33.* and automatic upgrade to “enabled with patch”
+^ Use Kubernetes version 1.34.* and automatic upgrade to “enabled with patch”
 
 #### AKS Node Pools Tab
 


### PR DESCRIPTION
Documentation-only follow-up to #112.

- `Docs/VersionCompatibility.md` - adds an `AKS 1.35` column. Virtual node `1.34` is marked compatible from `1.3410.26081102` onward, following the existing footnote style used for AKS 1.34.
- `README.md` - the AKS cluster creation steps now recommend Kubernetes `1.34.*` instead of `1.33.*` (two occurrences).

The full e2e suite was run against an AKS 1.35 control plane and passed. The chart uses only GA APIs, and upgrading a control plane from 1.34 to 1.35 caused no disruption to a running virtual node.

The footnote notes that virtual nodes continue to run 1.34 Kubernetes binaries against a 1.35 control plane, which is within the [supported version skew](https://kubernetes.io/releases/version-skew-policy/).
