### PR TITLE
Update index.yaml for chart version 1.3507.26090301

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,20 @@ apiVersion: v1
 entries:
   virtualnode:
   - apiVersion: v2
+    appVersion: 1.3507.26090301
+    created: "2026-09-04T06:41:26.382430751Z"
+    description: Helm chart to install virtual nodes on Azure Container Instances
+      to an existing Azure Kubernetes Service cluster.
+    digest: 88eae6f1f673e7a52fd039eb62a566184941ee7701eb56ffc17ce475f4ecf41c
+    maintainers:
+    - name: Gabriel Fuhrman
+      url: https://github.com/Gfuhrm
+    name: virtualnode
+    type: application
+    urls:
+    - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-1.3507.26090301/virtualnode-1.3507.26090301.tgz
+    version: 1.3507.26090301
+  - apiVersion: v2
     appVersion: 1.3410.26082101
     created: "2026-08-24T23:11:25.715387615Z"
     description: Helm chart to install virtual nodes on Azure Container Instances
@@ -641,4 +655,4 @@ entries:
     urls:
     - https://github.com/microsoft/virtualnodesOnAzureContainerInstances/releases/download/virtualnode-0.0.1/virtualnode-0.0.1.tgz
     version: 0.0.1
-generated: "2026-08-24T23:11:25.715646033Z"
+generated: "2026-09-04T06:41:26.382814135Z"


### PR DESCRIPTION
Adds the `virtualnode-1.3507.26090301` entry to `index.yaml`, generated by the Chart Releaser action after #119 merged.